### PR TITLE
security: CWE-252: Check error return from ParseReference — VC-53748

### DIFF
--- a/cmd/sigscan/repo.go
+++ b/cmd/sigscan/repo.go
@@ -293,7 +293,14 @@ func newRepoInspect(_ context.Context) *cobra.Command {
 								return err
 							}
 
-							ref, _ := name.ParseReference(imagePath + ":" + tag)
+							ref, err := name.ParseReference(imagePath + ":" + tag)
+							if err != nil {
+								log.WithFields(logrus.Fields{
+									"image_path": imagePath,
+									"tag":        tag,
+								}).Trace("ParseReference: " + err.Error())
+								continue
+							}
 
 							log.WithFields(logrus.Fields{
 								"ref":       ref.String(),


### PR DESCRIPTION
## Summary

Fixes CWE-252 (Unchecked Return Value) vulnerability by properly handling error returns from `name.ParseReference()` to prevent potential nil pointer dereferences.

## Finding

**Ticket:** VC-53748  
**CWE:** CWE-252 - Unchecked Return Value  
**Severity:** Medium  
**Location:** `cmd/sigscan/repo.go:296`

The error return value from `name.ParseReference()` was being ignored using the blank identifier (`_`). If parsing fails, the returned `ref` variable could be nil, and subsequent use of this nil reference (e.g., on line 304 in `FetchCosignImageSignatures`) would cause a nil pointer dereference and program crash.

## Remediation

Added proper error checking for `name.ParseReference()` call:
- Changed `ref, _ := name.ParseReference(...)` to `ref, err := name.ParseReference(...)`
- Added error handling that logs the failure and continues to the next tag
- This is consistent with existing error handling patterns in the same function (see lines 305-310)

The fix ensures that if parsing a reference fails for one tag, the error is logged and processing continues with the next tag, rather than causing a nil pointer dereference.

## Verification

The remediation:
- ✅ Properly checks error return value
- ✅ Prevents nil pointer dereference
- ✅ Maintains existing behavior (graceful degradation)
- ✅ Follows existing code patterns for error handling

**Note:** Build and test infrastructure encountered environment issues (GOROOT configuration), but the code change itself is minimal and follows established patterns in the codebase.