### PR TITLE
security: CWE-129: Fix manifest index panic — VC-53747

### DIFF
--- a/cmd/sigscan/repo.go
+++ b/cmd/sigscan/repo.go
@@ -365,6 +365,14 @@ func newRepoInspect(_ context.Context) *cobra.Command {
 										// Found NotaryV2 signature
 										sigCount += 1
 
+										// Validate manifest layers array before access
+										if len(manifest.Layers) == 0 {
+											log.WithFields(logrus.Fields{
+												"repo": repo + ":" + tag,
+											}).Debug("malformed manifest: no layers found")
+											continue
+										}
+
 										if outOpts.Mode == options.OutputModePretty {
 											log.WithFields(logrus.Fields{
 												"repo":                      repo + ":" + tag,
@@ -376,10 +384,18 @@ func newRepoInspect(_ context.Context) *cobra.Command {
 										}
 
 										if outOpts.Mode == options.OutputModeJSON {
+											// Validate annotations before access
+											thumbprint, ok := manifest.Annotations[registry.NotaryV2AnnotationThumbprint]
+											if !ok || len(thumbprint) < 2 {
+												log.WithFields(logrus.Fields{
+													"repo": repo + ":" + tag,
+												}).Debug("malformed manifest: invalid thumbprint annotation")
+												continue
+											}
 											out.Signatures.Entries = append(out.Signatures.Entries, output.RepoJSONSignature{
 												Path:                repo + ":" + tag,
 												Digest:              string(descriptor.Digest),
-												NotaryV2Thumbprints: manifest.Annotations[registry.NotaryV2AnnotationThumbprint][1 : len(manifest.Annotations[registry.NotaryV2AnnotationThumbprint])-1],
+												NotaryV2Thumbprints: thumbprint[1 : len(thumbprint)-1],
 											})
 										} else {
 											tbl.AddRow(repo+":"+tag, string(descriptor.Digest), "✅", "❌")


### PR DESCRIPTION
## Summary

This PR fixes a CWE-129 (Improper Validation of Array Index) vulnerability in sigscan's manifest parsing code that could allow a malformed OCI image manifest to cause an index-out-of-bounds panic, crashing the process.

## Finding

**CWE-129: Improper Validation of Array Index**  
**CVSS: 6.8** (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N)

When sigscan processes an OCI image manifest, it accesses the manifest layer array using an index without first validating that the index is within bounds. Specifically:

- Line 374: `manifest.Layers[0].MediaType` accessed without checking `len(manifest.Layers) > 0`
- Line 382: `manifest.Annotations[registry.NotaryV2AnnotationThumbprint]` accessed without validation

A malformed manifest where the declared layer count doesn't match the actual array length would cause an unrecovered Go panic (index out of range), terminating the process.

## Remediation

Added defensive bounds checking before array access:

1. **Manifest layers validation**: Check `len(manifest.Layers) > 0` before accessing `manifest.Layers[0]`. If empty, log a debug message and skip processing.

2. **Annotation validation**: Validate that the NotaryV2 thumbprint annotation exists and has sufficient length before slicing.

Both validations log debug messages and gracefully continue processing rather than panicking, preventing denial of service from malformed manifests.

## Verification

- Code builds successfully (pre-existing linting issues unrelated to this fix)
- Changes are minimal and focused on the vulnerability
- Malformed manifests will now return gracefully instead of panicking
- No functional changes to valid manifest processing